### PR TITLE
Removed console.log to keep the console clean

### DIFF
--- a/src/core/track.js
+++ b/src/core/track.js
@@ -183,7 +183,6 @@ export default class Track {
    * @param {Layer} layer - the layer to add to the track.
    */
   add(layer) {
-    console.log(layer);
     this.layers.push(layer);
     // Create a default renderingContext for the layer if missing
     this.$layout.appendChild(layer.$el);


### PR DESCRIPTION
I removed a console.log call from tracks.js that was logging a line in the console each time a new layer is added.